### PR TITLE
Feat/adds blog to nav

### DIFF
--- a/_tests_/components/nav/mobile-nav.test.jsx
+++ b/_tests_/components/nav/mobile-nav.test.jsx
@@ -31,12 +31,12 @@ describe("Mobile nav - opened", () => {
     // Open the nav menu
     mobileNavOpenButton.click();
 
-    const searchButton = screen.getByTitle("nav-search-button");
+    const learnButton = screen.getByTitle("nav-blog-button");
     const glossaryButton = screen.queryByTitle("nav-glossary-button");
     const closeButton = screen.getByTitle("mobile-nav-close-button");
     const chainLookupButton = screen.queryByTitle("nav-enspect-button");
 
-    expect(searchButton).toBeInTheDocument();
+    expect(learnButton).toBeInTheDocument();
     expect(closeButton).toBeInTheDocument();
     expect(glossaryButton).toBeInTheDocument();
     expect(chainLookupButton).toBeInTheDocument();

--- a/_tests_/components/nav/nav-items.test.jsx
+++ b/_tests_/components/nav/nav-items.test.jsx
@@ -10,19 +10,10 @@ describe("Right side Nav items", () => {
   it("It renders the Search button when on the glossary page", () => {
     render(<NavItems />);
 
-    const searchButton = screen.getByTitle("nav-search-button");
-    const searchButtonAllyText = screen.getByTitle(
-      "nav-search-button-a11y-text"
-    );
     const glossaryButton = screen.queryByTitle("nav-glossary-button");
     const chainLookupButton = screen.queryByTitle("nav-enspect-button");
     const blogButton = screen.queryByTitle("nav-blog-button");
 
-    expect(searchButton).toBeInTheDocument();
-    expect(searchButton).toHaveTextContent("search");
-    expect(searchButtonAllyText).toHaveTextContent(
-      "glossetaNavbarButtonA11yText"
-    );
     expect(glossaryButton).toBeInTheDocument();
     expect(chainLookupButton).toBeInTheDocument();
     expect(blogButton).toBeInTheDocument();

--- a/_tests_/components/nav/nav-items.test.jsx
+++ b/_tests_/components/nav/nav-items.test.jsx
@@ -16,6 +16,7 @@ describe("Right side Nav items", () => {
     );
     const glossaryButton = screen.queryByTitle("nav-glossary-button");
     const chainLookupButton = screen.queryByTitle("nav-enspect-button");
+    const blogButton = screen.queryByTitle("nav-blog-button");
 
     expect(searchButton).toBeInTheDocument();
     expect(searchButton).toHaveTextContent("search");
@@ -24,5 +25,6 @@ describe("Right side Nav items", () => {
     );
     expect(glossaryButton).toBeInTheDocument();
     expect(chainLookupButton).toBeInTheDocument();
+    expect(blogButton).toBeInTheDocument();
   });
 });

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -3,6 +3,7 @@
     "glossetaNavbarButtonA11yText": "Takes you to the main search page",
     "glossaryButton": "Glossary",
     "searchButtonTitle": "Search",
+    "blogButtonTitle": "Learn",
     "enspectButtonTitle": "ENSpect",
     "scrollToTheTopButton": "Click here to scroll to the top of the page",
 

--- a/src/components/nav/nav-items.tsx
+++ b/src/components/nav/nav-items.tsx
@@ -10,15 +10,9 @@ export default function NavItems() {
 
   return (
     <>
-      <Link href="/" passHref>
-        <Button color="white" variant="ghost" title="nav-search-button">
-          {t("searchButtonTitle")}
-          <span
-            className={styles.visuallyhidden}
-            title="nav-search-button-a11y-text"
-          >
-            {t("glossetaNavbarButtonA11yText")}
-          </span>
+      <Link href="https://blog.glosseta.com" passHref>
+        <Button color="white" variant="ghost" title="nav-blog-button">
+          {t("blogButtonTitle")}
         </Button>
       </Link>
       <Link href="/glossary" passHref>


### PR DESCRIPTION
### What does this PR do?

Adds the new [learn web3 blog](https://blog.glosseta.com) to the nav bar and removes the "search" nav bar item

### Any helpful background information around the changes?

In an effort to create more educational content we are introducing a new blog series called "Learn web3 with Glosseta"

### Any new dependencies? Why were they added?

### Relevant Screenshots/gifs

### Does is close any issue(s)?

Closes # ...